### PR TITLE
change input dir to list of video locations (can be dirs or files)

### DIFF
--- a/bboxes labelling/extract_frames_to_label_w_sleap.py
+++ b/bboxes labelling/extract_frames_to_label_w_sleap.py
@@ -12,6 +12,7 @@ Example usage:
 
 TODO: can I make it deterministic?
 TODO: check https://github.com/talmolab/sleap-io/tree/main/sleap_io
+TODO: change it to copy directory structure from input?
 '''
 
 import argparse
@@ -107,6 +108,7 @@ def extract_frames_to_label(args):
         parallel=args.compute_features_per_video,
     )
 
+    # sleap frames are 0-indexed (right?)
     map_videos_to_extracted_frames = get_map_videos_to_extracted_frames(
         list_sleap_videos,
         suggestions
@@ -117,7 +119,7 @@ def extract_frames_to_label(args):
     # ----------------------
     # create timestamp folder inside output folder if it doesnt exist
     timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-    output_dir_timestamped = Path(args.output_path) / f'{timestamp}'
+    output_dir_timestamped = Path(args.output_path) / f'{timestamp}' 
     output_dir_timestamped.mkdir(parents=True, exist_ok=True)
 
     # save extracted frames as json file
@@ -131,7 +133,7 @@ def extract_frames_to_label(args):
     )
 
     # -------------------------------------------------------
-    # For every video, extract suggested frames with opencv
+    # Extract suggested frames with opencv
     # -------------------------------------------------------
 
     # loop thru videos and extract frames
@@ -148,7 +150,11 @@ def extract_frames_to_label(args):
             continue
 
         # create video output dir inside timestamped one
-        video_output_dir = output_dir_timestamped / Path(vid_str).stem
+        video_output_dir = (
+            output_dir_timestamped /   # timestamp
+            Path(vid_str).parent.stem /  # parent dir of input video
+            Path(vid_str).stem  # video name
+        )
         video_output_dir.mkdir(parents=True, exist_ok=True)
 
         # go to the selected frames
@@ -213,7 +219,7 @@ if __name__ == '__main__':
                         type=str,
                         default='stride',
                         choices=['random', 'stride'],
-                        help='method to sample initial frames')   #ok?
+                        help='method to sample initial frames')  # ok?
     parser.add_argument('--scale', 
                         type=float, 
                         nargs='?', 

--- a/bboxes labelling/extract_frames_to_label_w_sleap.py
+++ b/bboxes labelling/extract_frames_to_label_w_sleap.py
@@ -167,9 +167,9 @@ def extract_frames_to_label(args):
 
         # create video output dir inside timestamped one
         video_output_dir = (
-            output_dir_timestamped /   # timestamp
-            Path(vid_str).parent.stem /  # parent dir of input video
-            Path(vid_str).stem  # video name
+            output_dir_timestamped  #/   # timestamp
+            # Path(vid_str).parent.stem /  # parent dir of input video
+            # Path(vid_str).stem  # video name
         )
         video_output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -187,7 +187,9 @@ def extract_frames_to_label(args):
 
             else:
                 file_path = video_output_dir / Path(
-                    f'frame_{frame_idx:06d}.png'
+                    f"{Path(vid_str).parent.stem}_"
+                    f"{Path(vid_str).stem}_"
+                    f"frame_{frame_idx:06d}.png"
                 )
                 img_saved = cv2.imwrite(
                     str(file_path),

--- a/bboxes labelling/run_frame_extraction.sh
+++ b/bboxes labelling/run_frame_extraction.sh
@@ -14,31 +14,19 @@
 # ---------------------
 # Load required modules
 # ----------------------
-# Option 1
-# module load cuda/11.8
-# module load miniconda
-# conda activate extract-frames  # ----> environment as defined in sleap installation
-
-# Option 2:
 module load SLEAP
 
 # ---------------------
 # Define environment variables
 # ----------------------
-SCRATCH_PERSONAL_DIR=/ceph/scratch/sminano
-INPUT_DIR=$SCRATCH_PERSONAL_DIR/crabs_sample/videos_inference  #--------- CHANGE
-OUTPUT_DIR=$SCRATCH_PERSONAL_DIR/crabs_bbox_labels
+# input/output dirs
+INPUT_DIR=/ceph/zoo/raw/CrabField/ramalhete_2021
+OUTPUT_DIR=/ceph/zoo/users/sminano/crabs_bboxes_labels
 
-# --------------------------
-# Set up conda environment
-# ---------------------------
-# conda activate extract-frames
-# TODO: re-creates it everytime?
-# use create -p instead?
-# conda create --name extract-frames python=3.7
-# conda activate extract-frames
-# conda install -c sleap -c nvidia -c conda-forge sleap
-# conda install -c conda-forge opencv
+# script location
+# assumes repo located at '/ceph/scratch/sminano'
+SCRATCH_PERSONAL_DIR=/ceph/scratch/sminano
+SCRIPT_DIR=$SCRATCH_PERSONAL_DIR/crabs-exploration/"bboxes labelling"
 
 # TODO: set NUMEXPR_MAX_THREADS?
 # NumExpr detected 40 cores but "NUMEXPR_MAX_THREADS" not set, 
@@ -47,9 +35,8 @@ OUTPUT_DIR=$SCRATCH_PERSONAL_DIR/crabs_bbox_labels
 # -------------------
 # Run python script
 # -------------------
-cd $OUTPUT_DIR
-python extract_frames_to_label_w_sleap.py \
- $INPUT_DIR \
+python $SCRIPT_DIR/extract_frames_to_label_w_sleap.py \
+ $INPUT_DIR/camera1 $INPUT_DIR/camera2/NINJAV_S001_S001_T001.MOV  $INPUT_DIR/camera2/NINJAV_S001_S001_T002.MOV\
  --output_path $OUTPUT_DIR \
  --video_extensions 'MOV' \
  --initial_samples 300 \


### PR DESCRIPTION
In pipeline for extracting frames to label:
- I changed the input directory argument to take a list of directories or specific video files
- I changed the naming of the extracted frames, so that the name of the camera (i.e., the videos parent dir) and the name of the video file are included in the name of the frame extracted. This way we retain this information when we export the labels in COCO format.
- I changed the prints to logging module calls